### PR TITLE
Rename default branch references from master to main

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -3,7 +3,7 @@ name: Build Check
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 6 * * 2" # Rebuild weekly on Tuesdays to pick up base image and dependency updates
   push:
-    branches: [master]
+    branches: [main]
     tags: ["v*"]
 
 env:
@@ -62,7 +62,7 @@ jobs:
           tags: |
             type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=master
+            type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -62,7 +62,6 @@ jobs:
           tags: |
             type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
Updates all workflow files to reference `main` instead of `master` to match the renamed default branch.