### PR TITLE
Run all checks on push to main as well as PRs

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,6 +1,9 @@
 name: Build Check
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,6 +1,9 @@
 name: Smoke Test
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Adds `push` trigger for the `main` branch to Build Check, Lint, and Smoke Test workflows so they run on both PRs and direct pushes to main.