### PR TITLE
Always tag Docker image with hexo-cli version

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -62,7 +62,7 @@ jobs:
             ${{ env.GHCR_IMAGE }}
             ${{ env.HAS_DOCKERHUB == 'true' && env.DOCKERHUB_IMAGE || '' }}
           tags: |
-            type=raw,value=${{ steps.get_version.outputs.VERSION }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Removes the `refs/tags/` gate on the hexo-cli version tag so every publish (push to main, weekly schedule, manual dispatch) tags the image with the current hexo-cli version (e.g. `:4.3.2`).