### PR TITLE
ci: add build provenance attestation for GHCR images

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     env:
       HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
 
@@ -64,12 +66,14 @@ jobs:
           tags: |
             type=raw,value=${{ steps.get_version.outputs.VERSION }}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDD'}}-{{sha}},enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -79,3 +83,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest GHCR image
+        uses: actions/attest-build-provenance@a2bbfa2fc6a1ec227d5872979d9e9bbb84cc1043 # v4.1.0
+        with:
+          subject-name: ${{ env.GHCR_IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Adds [SLSA build provenance](https://slsa.dev/) attestation to the publish workflow using `actions/attest-build-provenance@v4.1.0`.

## Changes
- Added `id-token: write` and `attestations: write` permissions to the publish job
- Added an `Attest GHCR image` step after build-and-push that generates and pushes provenance to the GHCR registry

## What this enables
Consumers can verify image provenance with:
```bash
gh attestation verify oci://ghcr.io/fletchto99/hexo-dev-docker:latest --owner fletchto99
```