### PR TITLE
fix: correct attest-build-provenance SHA pin

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -85,7 +85,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Attest GHCR image
-        uses: actions/attest-build-provenance@a2bbfa2fc6a1ec227d5872979d9e9bbb84cc1043 # v4.1.0
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.GHCR_IMAGE }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
The SHA pin for `actions/attest-build-provenance@v4.1.0` merged in #15 was invalid. This fixes it to the correct commit SHA: `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`.