### PR TITLE
ci: gate publish on smoke test

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,7 +18,11 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
+  smoke-test:
+    uses: ./.github/workflows/smoke_test.yml
+
   build-and-push:
+    needs: smoke-test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 jobs:
   smoke-test:


### PR DESCRIPTION
Adds a `smoke-test` job to `publish_release.yml` that `build-and-push` depends on via `needs: smoke-test`.

This ensures the smoke test gates **all** publish triggers — weekly schedule, manual dispatch, and push to main — not just PRs (which the standalone `smoke_test.yml` already covers).

The smoke test logic mirrors the existing `smoke_test.yml`:
1. Builds the image
2. Starts a container with an empty config volume
3. Waits for the hexo server to respond
4. Verifies blog initialization (`_config.yml`, `source/_posts`)
5. Checks HTTP 200 response