### PR TITLE
Remove redundant sha tag from Docker metadata

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -74,7 +74,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
 
       - name: Build and push
         id: push


### PR DESCRIPTION
Removes the `type=sha` tag from the metadata action. The commit SHA is already included in the date-based tag (`YYYYMMDD-sha`), making the standalone `sha-abc1234` tag redundant.