### PR TITLE
Add delete-untagged to GHCR cleanup

### DIFF
--- a/.github/workflows/cleanup_ghcr.yml
+++ b/.github/workflows/cleanup_ghcr.yml
@@ -14,5 +14,6 @@ jobs:
       - name: Delete orphaned images
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1
         with:
+          delete-untagged: true
           delete-orphaned-images: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `delete-untagged: true` so old releases that lose their tag via `keep-n-tagged` are actually deleted, allowing `delete-orphaned-images` to cascade-clean their attestation `sha256-*` referrer tags.