### PR TITLE
Add keep-n-tagged: 10 to GHCR cleanup

### DIFF
--- a/.github/workflows/cleanup_ghcr.yml
+++ b/.github/workflows/cleanup_ghcr.yml
@@ -16,4 +16,5 @@ jobs:
         with:
           delete-untagged: true
           delete-orphaned-images: true
+          keep-n-tagged: 10
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup_ghcr.yml
+++ b/.github/workflows/cleanup_ghcr.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           delete-untagged: true
           delete-orphaned-images: true
-          keep-n-tagged: 10
+          keep-n-tagged: 20
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Without this, old tagged images accumulate indefinitely. Keeps the 10 most recent tagged packages (~2-3 releases worth).