### PR TITLE
fix: always update plugins to latest on container start

### DIFF
--- a/setup/run.sh
+++ b/setup/run.sh
@@ -19,10 +19,20 @@ fi
 if [[ -z "${HEXO_PLUGINS}" ]]; then
   echo "No additional plugins to install!"
 else
-  echo "Installing additional plugins \"${HEXO_PLUGINS}\""
+  # Append @latest to each plugin name so existing packages get updated
+  PLUGINS_LATEST=""
+  for plugin in ${HEXO_PLUGINS}; do
+    # Only append @latest if no version specifier is present
+    if [[ "$plugin" == *@* ]]; then
+      PLUGINS_LATEST="$PLUGINS_LATEST $plugin"
+    else
+      PLUGINS_LATEST="$PLUGINS_LATEST $plugin@latest"
+    fi
+  done
+  echo "Installing/updating plugins:${PLUGINS_LATEST}"
   # Word splitting is intentional here to pass multiple package names
   # shellcheck disable=SC2086
-  npm install -C /config ${HEXO_PLUGINS}
+  npm install -C /config ${PLUGINS_LATEST}
 fi
 
 # Start the server


### PR DESCRIPTION
When `/config` is a mounted volume, `npm install` skips packages that already exist in `node_modules`. This appends `@latest` to each plugin name so npm always pulls the newest version on container start.

Respects explicit version specifiers — e.g. `hexo-some-plugin@2.0.0` won't get `@latest` appended.