### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   GHCR_REGISTRY: ghcr.io
   GHCR_IMAGE: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/fletchto99/hexo-dev-docker/security/code-scanning/1](https://github.com/fletchto99/hexo-dev-docker/security/code-scanning/1)

Add a root-level `permissions` block in `.github/workflows/publish_release.yml` so all jobs inherit least-privilege defaults, including `smoke-test` on line 21. Keep existing job-specific permissions for `build` unchanged so its required `packages: write` remains intact.

Best fix here:
- Insert at workflow root (after `on:` block, before `env:`):
  - `permissions:`
  - `contents: read`
  - `packages: read`

Why this is best:
- It directly addresses the flagged missing-permissions condition for the reusable workflow job.
- It does not change existing functionality of `build` because job-level permissions override inherited defaults.
- It documents baseline token scope and keeps behavior safer if defaults change later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
