### PR TITLE
Add tini as init process for proper signal handling

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -56,6 +56,11 @@ jobs:
           echo "HTTP status: $status"
           [ "$status" = "200" ]
 
+      - name: Verify graceful shutdown
+        run: |
+          timeout 5 docker stop hexo-test
+          echo "Container stopped gracefully"
+
       - name: Cleanup
         if: always()
         run: docker rm -f hexo-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25-bookworm-slim
 
 # Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends rsync openssh-client && \
+    apt-get install -y --no-install-recommends rsync openssh-client tini && \
     rm -rf /var/lib/apt/lists/*
 
 # Install hexo-cli at the version pinned in package-lock.json
@@ -19,4 +19,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:8080/', r => r.statusCode === 200 ? process.exit(0) : process.exit(1)).on('error', () => process.exit(1))"
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/bin/bash", "/setup/run.sh"]


### PR DESCRIPTION
## Problem
The container takes a long time to stop because the hexo server running as PID 1 ignores SIGTERM by default (Linux PID 1 signal semantics). Docker waits the full stop timeout (default 10s) then sends SIGKILL.

## Fix
Add **tini** as the container entrypoint. tini runs as PID 1 and properly forwards signals to child processes, making `docker stop` near-instant. It also handles zombie process reaping.

### Changes
- Added `tini` to the `apt-get install` list
- Added `ENTRYPOINT ["/usr/bin/tini", "--"]` before the existing `CMD`